### PR TITLE
Get rid of warning about deprecated method

### DIFF
--- a/src/createKeyboardAwareNavigator.js
+++ b/src/createKeyboardAwareNavigator.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TextInput } from 'react-native';
+import { TextInput, Keyboard } from 'react-native';
 
 export default (Navigator, navigatorConfig) =>
   class KeyboardAwareNavigator extends React.Component {
@@ -45,7 +45,7 @@ export default (Navigator, navigatorConfig) =>
       if (transitionProps.index !== prevTransitionProps.index) {
         const currentField = TextInput.State.currentlyFocusedField();
         if (currentField) {
-          TextInput.State.blurTextInput(currentField);
+          Keyboard.dismiss();
         }
       }
 


### PR DESCRIPTION
Fixes https://github.com/react-navigation/react-navigation/issues/5144