### PR TITLE
[Fix RN TextInput focus bug with react-navigation] Add a condition to blur the currently focused textinput

### DIFF
--- a/src/createKeyboardAwareNavigator.js
+++ b/src/createKeyboardAwareNavigator.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TextInput } from 'react-native';
+import { TextInput, UIManager } from 'react-native';
 
 export default (Navigator, navigatorConfig) =>
   class KeyboardAwareNavigator extends React.Component {
@@ -43,9 +43,26 @@ export default (Navigator, navigatorConfig) =>
       // in the case where the index did not change, I believe. We
       // should revisit this after 2.0 release.
       if (transitionProps.index !== prevTransitionProps.index) {
-        const currentField = TextInput.State.currentlyFocusedField();
-        if (currentField) {
-          TextInput.State.blurTextInput(currentField);
+        const currentFocusedField = TextInput.State.currentlyFocusedField();
+        if (currentFocusedField) {
+          const previousSceneTag =
+            prevTransitionProps &&
+            prevTransitionProps.scene &&
+            prevTransitionProps.scene.route &&
+            prevTransitionProps.scene.route.params &&
+            prevTransitionProps.scene.route.params.nodeTag;
+          if (previousSceneTag) {
+            UIManager.viewIsDescendantOf(
+              currentFocusedField,
+              previousSceneTag,
+              isDescendant => {
+                if (isDescendant)
+                  TextInput.State.blurTextInput(currentFocusedField);
+              }
+            );
+          } else {
+            TextInput.State.blurTextInput(currentFocusedField);
+          }
         }
       }
 


### PR DESCRIPTION
I noticed a bug while using react-navigation + the react-native TextInput component.

HOW TO REPRODUCE THE BUG :

Let’s consider the following app with only 2 pages :

Page1.js :
`import React, { PureComponent } from 'react';
import { TouchableOpacity, View, Text } from 'react-native';

export default class Page1 extends PureComponent {
  render() {
    return (
      <View>
        <TouchableOpacity
          style={{ backgroundColor: 'red', height: 30, justifyContent: 'center', alignItems: 'center' }}
          onPress={() => this.props.navigation.navigate('Page2')}
        >
          <Text>Go to page 2</Text>
        </TouchableOpacity>
      </View>
    );
  }
}`

Page2.js :
`import React, { PureComponent } from 'react';
import { TouchableOpacity, TextInput, Keyboard, View, Text } from 'react-native';

export default class Page2 extends PureComponent {
  componentDidMount() {
    this.textInput && this.textInput.focus();
  }

  render() {
    return (
      <View>
        <TextInput ref={ref => (this.textInput = ref)} placeholder={'Write something here'} />
        <TouchableOpacity
          style={{ backgroundColor: 'blue', height: 30, marginTop: 20, justifyContent: 'center', alignItems: 'center' }}
          onPress={Keyboard.dismiss}
        >
          <Text>Dismiss keyboard</Text>
        </TouchableOpacity>
      </View>
    );
  }
}`

App.js :
`import React, { Component } from 'react';
import { createStackNavigator, createAppContainer } from 'react-navigation';
import * as Pages from './pages';

const RootNavigator = createStackNavigator(
  {
    Page1: {
      screen: Pages.Page1,
    },
    Page2: {
      screen: Pages.Page2,
    },
  },
  {
    initialRouteName: 'Page1',
  }
);

const AppContainer = createAppContainer(RootNavigator);

class App extends Component {
  render() {
    return <AppContainer />;
  }
}

export default App;`

On Page1 you have a single button to navigate to Page2. On Page2, you’d like that a TextInput is focused when you arrive on this page. You also have a « dismiss » button to close de keyboard when the textinput is focused.

You could use the TextInput props « autoFocus » so that it is focused at the beginning. There is absolutely no bug in this case.
But instead, I tried to create a ref « textinput » for the TextInput component, and called this.textinput.focus() in the componentDidMount method to focus it at the beginning. It works, but in this case, when I click on the dismiss button, the keyboard won’t close.

After digging, I found that a blur call is made when you arrive on Page2, coming from the @react-navigation/native/src/KeyboardAwareNavigator.js file. In _handleTransitionStart, transitionProps.index !== prevTransitionProps.index is true because you are switching pages, and !!currentField too in the « this.textinput.focus() » case. As a consequence, it blurs the textinput, the TextInput.State.currentlyFocusedField() becomes null, and you cannot dismiss the keyboard anymore.

My fix :

I tried to add another condition than the if(currentField) when we should blur the currently focused textinput. According to me, it should be something like if(currentField && previousPage includes currentField) or if(currentField && currentPage does not include currentField)

To do so, I used the viewIsDescendantOf method from UIManager, react-native. In addition to the tag of the currently focused field (which is precisely currentField), I needed the tag of the previous scene, which may be its parent (see : https://github.com/react-navigation/react-navigation-core/pull/19)