### PR TITLE
Customize URL listener and initial url

### DIFF
--- a/src/createAppContainer.js
+++ b/src/createAppContainer.js
@@ -204,7 +204,6 @@ export default function createNavigationContainer(Component) {
         }
       }
       _statefulContainerCount++;
-      Linking.addEventListener('url', this._handleOpenURL);
 
       // Pull out anything that can impact state
       const {
@@ -276,15 +275,20 @@ export default function createNavigationContainer(Component) {
           })
         );
 
-      if (startupState === this.state.nav) {
+      const onFinishSettingUpNavState = () => {
+        Linking.addEventListener('url', this._handleOpenURL);
         dispatchActions();
+      };
+
+      if (startupState === this.state.nav) {
+        onFinishSettingUpNavState();
         return;
       }
 
       // eslint-disable-next-line react/no-did-mount-set-state
       this.setState({ nav: startupState }, () => {
         _reactNavigationIsHydratingState = false;
-        dispatchActions();
+        onFinishSettingUpNavState();
       });
     }
 

--- a/src/createAppContainer.js
+++ b/src/createAppContainer.js
@@ -276,7 +276,9 @@ export default function createNavigationContainer(Component) {
         );
 
       const onFinishSettingUpNavState = () => {
-        Linking.addEventListener('url', this._handleOpenURL);
+        this.props.addUrlListener
+          ? this.props.addUrlListener(this._handleOpenURL)
+          : Linking.addEventListener('url', this._handleOpenURL);
         dispatchActions();
       };
 
@@ -314,7 +316,18 @@ export default function createNavigationContainer(Component) {
 
     componentWillUnmount() {
       this._isMounted = false;
-      Linking.removeEventListener('url', this._handleOpenURL);
+
+      if (this.props.addUrlListener) {
+        const { removeUrlListener } = this.props;
+        invariant(
+          removeUrlListener,
+          'should be provided when using addUrlListener'
+        );
+        removeUrlListener(this._handleOpenURL);
+      } else {
+        Linking.removeEventListener('url', this._handleOpenURL);
+      }
+
       this.subs && this.subs.remove();
 
       if (this._isStateful()) {

--- a/src/createAppContainer.js
+++ b/src/createAppContainer.js
@@ -207,13 +207,20 @@ export default function createNavigationContainer(Component) {
       Linking.addEventListener('url', this._handleOpenURL);
 
       // Pull out anything that can impact state
-      const { persistenceKey, uriPrefix, enableURLHandling } = this.props;
+      const {
+        persistenceKey,
+        uriPrefix,
+        enableURLHandling,
+        getInitialUrl,
+      } = this.props;
       let parsedUrl = null;
       let startupStateJSON = null;
       if (enableURLHandling !== false) {
         startupStateJSON =
           persistenceKey && (await AsyncStorage.getItem(persistenceKey));
-        const url = await Linking.getInitialURL();
+        const url = getInitialUrl
+          ? await getInitialUrl()
+          : await Linking.getInitialURL();
         parsedUrl = url && urlToPathAndParams(url, uriPrefix);
       }
 


### PR DESCRIPTION
Sometimes you want to customize the URL listener and initial URL, for example with Firebase Dynamic Links.

Here's what it would look like roughly with Firebase Dynamic Links : 

```js
class Navigator extends Component<PropsType> {
  getInitialUrl = () => firebase.links().getInitialLink();

  addUrlListener = handleOpenURL => {
    this.unsubscribeFirebaseLinkListener = firebase.links().onLink(url => handleOpenURL({ url }));
  };

  removeUrlListener = () => {
    this.unsubscribeFirebaseLinkListener && this.unsubscribeFirebaseLinkListener();
  };

  render() {
    return (
      <RootNavigator
        getInitialUrl={this.getInitialUrl}
        addUrlListener={this.addUrlListener}
        removeUrlListener={this.removeUrlListener}
      />
    );
  }
}
```

Happy to rename things too, I wasn't very inspired :)