### PR TITLE
Support scroll to top when getNode returns the ref

### DIFF
--- a/src/createNavigationAwareScrollable.js
+++ b/src/createNavigationAwareScrollable.js
@@ -20,6 +20,8 @@ export default function createNavigationAwareScrollable(Component: any) {
                 scrollableNode.scrollToTop();
               } else if (scrollableNode.scrollTo != null) {
                 scrollableNode.scrollTo({ y: 0 });
+              } else if (scrollableNode.scrollResponderScrollTo != null) {
+                scrollableNode.scrollResponderScrollTo({ y: 0 });
               }
             }
           }


### PR DESCRIPTION
Currently the `getNode` function returns the scrollable ref if both `getScrollResponder` and `getNode` methods doesn't exist.
This commit adds support to scroll to the top via `scrollResponderScrollTo` method from ref.