### PR TITLE
use 'screen' instead of 'window' when getting Dimentions

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,15 +59,13 @@
     "react": "16.6.3",
     "react-dom": "16.3.2",
     "react-native": "^0.57.7",
+    "react-native-safe-area-context": "^0.3.5",
     "react-navigation": "^2.11.2",
     "react-test-renderer": "16.6.3",
     "release-it": "^7.6.1"
   },
   "peerDependencies": {
-    "@react-navigation/core": "^3.0.0",
-    "react": "*",
-    "react-native": "*",
-    "react-native-gesture-handler": "*"
+    "react-native-safe-area-context": "*"
   },
   "jest": {
     "preset": "react-native",
@@ -91,7 +89,7 @@
   },
   "dependencies": {
     "hoist-non-react-statics": "^3.0.1",
-    "react-native-safe-area-view": "^0.14.1",
+    "react-native-safe-area-view": "^0.14",
     "react-native-screens": "^1.0.0 || ^1.0.0-alpha"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-navigation/native",
-  "version": "3.6.2",
+  "version": "4.0.0-alpha.0",
   "description": "React Native support for React Navigation",
   "main": "dist/index.js",
   "files": [

--- a/src/createAppContainer.js
+++ b/src/createAppContainer.js
@@ -7,6 +7,7 @@ import {
   getNavigation,
   NavigationProvider,
 } from '@react-navigation/core';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 import invariant from './utils/invariant';
 import docsUrl from './utils/docsUrl';
 
@@ -425,11 +426,13 @@ export default function createNavigationContainer(Component) {
       invariant(navigation, 'failed to get navigation');
 
       return (
-        <ThemeProvider value={this._getTheme()}>
-          <NavigationProvider value={navigation}>
-            <Component {...this.props} navigation={navigation} />
-          </NavigationProvider>
-        </ThemeProvider>
+        <SafeAreaProvider>
+          <ThemeProvider value={this._getTheme()}>
+            <NavigationProvider value={navigation}>
+              <Component {...this.props} navigation={navigation} />
+            </NavigationProvider>
+          </ThemeProvider>
+        </SafeAreaProvider>
       );
     }
   }

--- a/src/withOrientation.js
+++ b/src/withOrientation.js
@@ -9,7 +9,7 @@ export default function(WrappedComponent) {
     constructor() {
       super();
 
-      const isLandscape = isOrientationLandscape(Dimensions.get('window'));
+      const isLandscape = isOrientationLandscape(Dimensions.get('screen'));
       this.state = { isLandscape };
     }
 
@@ -21,8 +21,8 @@ export default function(WrappedComponent) {
       Dimensions.removeEventListener('change', this.handleOrientationChange);
     }
 
-    handleOrientationChange = ({ window }) => {
-      const isLandscape = isOrientationLandscape(window);
+    handleOrientationChange = ({ screen }) => {
+      const isLandscape = isOrientationLandscape(screen);
       this.setState({ isLandscape });
     };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7134,6 +7134,11 @@ react-native-drawer-layout@1.3.2:
   dependencies:
     react-native-dismiss-keyboard "1.0.0"
 
+react-native-safe-area-context@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-0.3.5.tgz#1bfe0d1d4f5fb3462c07e3337d2f71eb1932c570"
+  integrity sha512-nh3Q4mmPmaCr1q0hHsReWXL8nlYKXOtLpPNeN57V1bB/QyJ7zL0nYR6c0cDR2/wPBA/DNm4wNllUAT842xb2zw==
+
 react-native-safe-area-view@0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-native-safe-area-view/-/react-native-safe-area-view-0.11.0.tgz#4f3dda43c2bace37965e7c6aef5fc83d4f19d174"
@@ -7141,10 +7146,10 @@ react-native-safe-area-view@0.11.0:
   dependencies:
     hoist-non-react-statics "^2.3.1"
 
-react-native-safe-area-view@^0.14.1:
-  version "0.14.1"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-view/-/react-native-safe-area-view-0.14.1.tgz#3981f6f8628c1769a163313bd8c8eba5edecca0f"
-  integrity sha512-pLAPWdirNWO/1F6IYkbayW9nDIXkM2F/NPtigYNjZj9nISCW+G2dNuI39DI8LenkxYdhiDaGMXfQHHx9TRn6Fw==
+react-native-safe-area-view@^0.14:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-view/-/react-native-safe-area-view-0.14.8.tgz#ef33c46ff8164ae77acad48c3039ec9c34873e5b"
+  integrity sha512-MtRSIcZNstxv87Jet+UsPhEd1tpGe8cVskDXlP657x6rHpSrbrc+y13ZNXrwAgGNNhqQNX7UJT68ZIq//ZRmvw==
   dependencies:
     hoist-non-react-statics "^2.3.1"
 


### PR DESCRIPTION
I created this pull request in favour of this issue: https://github.com/react-navigation/stack/issues/217

However I'm not sure if this will solve the issue after updating `react-native-safe-area-view` to v1.0 in this repo.