### PR TITLE
Bump @expo/vector-icon version it throws deprecated warning in expo sdk 36

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,15 +59,13 @@
     "react": "16.6.3",
     "react-dom": "16.3.2",
     "react-native": "^0.57.7",
+    "react-native-safe-area-context": "^0.3.5",
     "react-navigation": "^2.11.2",
     "react-test-renderer": "16.6.3",
     "release-it": "^7.6.1"
   },
   "peerDependencies": {
-    "@react-navigation/core": "^3.0.0",
-    "react": "*",
-    "react-native": "*",
-    "react-native-gesture-handler": "*"
+    "react-native-safe-area-context": "*"
   },
   "jest": {
     "preset": "react-native",
@@ -91,7 +89,7 @@
   },
   "dependencies": {
     "hoist-non-react-statics": "^3.0.1",
-    "react-native-safe-area-view": "^0.14.1",
+    "react-native-safe-area-view": "^0.14",
     "react-native-screens": "^1.0.0 || ^1.0.0-alpha"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/react-navigation/react-navigation-native#readme",
   "devDependencies": {
-    "@expo/vector-icons": "^6.2.0",
+    "@expo/vector-icons": "^10.0.6",
     "@react-navigation/core": "^3.5.0-alpha.4",
     "babel-cli": "^6.26.0",
     "babel-jest": "^22.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-navigation/native",
-  "version": "3.6.2",
+  "version": "4.0.0-alpha.0",
   "description": "React Native support for React Navigation",
   "main": "dist/index.js",
   "files": [

--- a/src/createAppContainer.js
+++ b/src/createAppContainer.js
@@ -7,6 +7,7 @@ import {
   getNavigation,
   NavigationProvider,
 } from '@react-navigation/core';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 import invariant from './utils/invariant';
 import docsUrl from './utils/docsUrl';
 
@@ -425,11 +426,13 @@ export default function createNavigationContainer(Component) {
       invariant(navigation, 'failed to get navigation');
 
       return (
-        <ThemeProvider value={this._getTheme()}>
-          <NavigationProvider value={navigation}>
-            <Component {...this.props} navigation={navigation} />
-          </NavigationProvider>
-        </ThemeProvider>
+        <SafeAreaProvider>
+          <ThemeProvider value={this._getTheme()}>
+            <NavigationProvider value={navigation}>
+              <Component {...this.props} navigation={navigation} />
+            </NavigationProvider>
+          </ThemeProvider>
+        </SafeAreaProvider>
       );
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -732,13 +732,12 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@expo/vector-icons@^6.2.0":
-  version "6.3.1"
-  resolved "https://registry.yarnpkg.com/@expo/vector-icons/-/vector-icons-6.3.1.tgz#ffb97cc2343e4a330b44ce3063ee7c8571a6a50d"
-  integrity sha512-ai3Ub/r8oCduIBa/rX1tVba3WlazIar8faVz6hrpbe6rX67LS32C+HmrFKJ1VxUeMDyoNOUXzrk9hge5jD/HYg==
+"@expo/vector-icons@^10.0.6":
+  version "10.0.6"
+  resolved "https://registry.yarnpkg.com/@expo/vector-icons/-/vector-icons-10.0.6.tgz#5718953ff0b97827d11dae5787976fa8ce5caaed"
+  integrity sha512-qNlKPNdf073LpeEpyClxAh0D3mmIK4TGAQzeKR0HVwf14RIEe17+mLW5Z6Ka5Ho/lUtKMRPDHumSllFyKvpeGg==
   dependencies:
     lodash "^4.17.4"
-    react-native-vector-icons "4.5.0"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -5666,7 +5665,7 @@ lodash.throttle@^4.1.1:
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
   integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
 
-lodash@4.17.11, lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
+lodash@4.17.11, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -6969,7 +6968,7 @@ prompts@^0.1.9:
     kleur "^2.0.1"
     sisteransi "^0.1.1"
 
-prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
+prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -7171,15 +7170,6 @@ react-native-tab-view@^1.0.0:
   integrity sha512-iufNROTPr4+Z/IKijlp5faEANiDBWxhpgx9NSCg3esZ+HN5+UtFwB0xkn4XpNRqCvbzeBkgKMRJL3V6kr5NhWg==
   dependencies:
     prop-types "^15.6.1"
-
-react-native-vector-icons@4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-4.5.0.tgz#6b95619e64f62f05f579f74a01fe5640df95158b"
-  integrity sha512-A2HdvmYxAohZ3w8FgdMi5kl3pUEXOz9sR3zsfpejIdispqAh6NRAHCqsI6DMRcymNgwWzmqLowPqp9eg5zqWLA==
-  dependencies:
-    lodash "^4.0.0"
-    prop-types "^15.5.10"
-    yargs "^8.0.2"
 
 react-native@^0.57.7:
   version "0.57.8"
@@ -9167,25 +9157,6 @@ yargs@^11.0.0:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^9.0.2"
-
-yargs@^8.0.2:
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
-  integrity sha1-YpmpBVsc78lp/355wdkY3Osiw2A=
-  dependencies:
-    camelcase "^4.1.0"
-    cliui "^3.2.0"
-    decamelize "^1.1.1"
-    get-caller-file "^1.0.1"
-    os-locale "^2.0.0"
-    read-pkg-up "^2.0.0"
-    require-directory "^2.1.1"
-    require-main-filename "^1.0.1"
-    set-blocking "^2.0.0"
-    string-width "^2.0.0"
-    which-module "^2.0.0"
-    y18n "^3.2.1"
-    yargs-parser "^7.0.0"
 
 yargs@^9.0.0:
   version "9.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7134,6 +7134,11 @@ react-native-drawer-layout@1.3.2:
   dependencies:
     react-native-dismiss-keyboard "1.0.0"
 
+react-native-safe-area-context@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-0.3.5.tgz#1bfe0d1d4f5fb3462c07e3337d2f71eb1932c570"
+  integrity sha512-nh3Q4mmPmaCr1q0hHsReWXL8nlYKXOtLpPNeN57V1bB/QyJ7zL0nYR6c0cDR2/wPBA/DNm4wNllUAT842xb2zw==
+
 react-native-safe-area-view@0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-native-safe-area-view/-/react-native-safe-area-view-0.11.0.tgz#4f3dda43c2bace37965e7c6aef5fc83d4f19d174"
@@ -7141,10 +7146,10 @@ react-native-safe-area-view@0.11.0:
   dependencies:
     hoist-non-react-statics "^2.3.1"
 
-react-native-safe-area-view@^0.14.1:
-  version "0.14.1"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-view/-/react-native-safe-area-view-0.14.1.tgz#3981f6f8628c1769a163313bd8c8eba5edecca0f"
-  integrity sha512-pLAPWdirNWO/1F6IYkbayW9nDIXkM2F/NPtigYNjZj9nISCW+G2dNuI39DI8LenkxYdhiDaGMXfQHHx9TRn6Fw==
+react-native-safe-area-view@^0.14:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-view/-/react-native-safe-area-view-0.14.8.tgz#ef33c46ff8164ae77acad48c3039ec9c34873e5b"
+  integrity sha512-MtRSIcZNstxv87Jet+UsPhEd1tpGe8cVskDXlP657x6rHpSrbrc+y13ZNXrwAgGNNhqQNX7UJT68ZIq//ZRmvw==
   dependencies:
     hoist-non-react-statics "^2.3.1"
 


### PR DESCRIPTION
This packages uses very low version of `@expo/vector-icon`.

This is the search result I get when I search for `@expo/vector-icons` version in my `node_modules` folder.

![expo-vector-icon](https://user-images.githubusercontent.com/17236768/70864630-e4e5f100-1f79-11ea-90f9-6bd96f0089f0.png)
